### PR TITLE
Portability improvements

### DIFF
--- a/src/bagman.cpp
+++ b/src/bagman.cpp
@@ -118,16 +118,21 @@ class MainClass : public Abortable
 
     MainClass *c = (MainClass *)param;
 
+    // shouldn't we be using exceptions for this?
+ #ifdef USE_EXCEPTIONS
     try
+    #endif
     {
       c->video_update(interval);
     }
+ #ifdef USE_EXCEPTIONS
     catch (const Abortable::Cause &cs)
     {
       c->error(cs,false);
       exit(1);
 
     }
+    #endif
     #endif
 
     return interval;

--- a/src/engine/MPLevel.cpp
+++ b/src/engine/MPLevel.cpp
@@ -889,12 +889,12 @@ GameContext *MPLevel::update_running(int elapsed_time)
 	      m_first_update = false;
 	      if ((current_screen==0 || current_screen==2) and RandomNumber::rand(2)==0)
 		{
-		  #ifdef _WIN32
-		  MyString track_name = DirectoryBase::get_sound_path() / "track" + MyString(current_screen+1)+".mp3";
-		  m_domain->sound_set.play_music(track_name);
-		  #elif __amigaos
+		  #ifdef __amigaos
 		  MyString track_name = DirectoryBase::get_sound_path() / "bagman_00112.mod";
 		  m_domain->sound_set.play_music(track_name,current_screen == 0 ? 0 : 3);
+                  #else
+                  MyString track_name = DirectoryBase::get_sound_path() / "track" + MyString(current_screen+1)+".mp3";
+                  m_domain->sound_set.play_music(track_name);
 		  #endif
 
 		}

--- a/src/engine/TileGrid.cpp
+++ b/src/engine/TileGrid.cpp
@@ -141,7 +141,7 @@ void TileGrid::init()
       MyFile f(mapfile);
       StreamPosition file_len;
       char *contents = (char *)f.read_all(file_len);
-      if (file_len == 0)
+      if (file_len <= 0)
 	{
 	  abort_run("cannot load %q",mapfile);
 	}

--- a/src/sys/Abortable.cpp
+++ b/src/sys/Abortable.cpp
@@ -351,7 +351,11 @@ void Abortable::abort_run(MSG_ARG_PROTO) const
   throw(Cause
 	(format_message(message,MSG_ARG_LIST),
 	 get_current_entrypoint()));
-  #endif
+    #else
+  // avoid unused warning/error
+  const MyString arr[]{message,MSG_ARG_LIST};
+  (void)arr;
+#endif
 }
 
 // JFF: kind of printf emulation, not complete, but with extra features

--- a/src/sys/Abortable.hpp
+++ b/src/sys/Abortable.hpp
@@ -3,7 +3,7 @@
 #include "GsDefine.hpp"
 #include "MyMacros.hpp"
 #include "MyString.hpp"
-#ifdef _WIN32
+#if !defined(_NDS) && !defined(__amigaos__)
 #include "FunctionTimer.hpp"
 #endif
 #include "FunctionId.hpp"

--- a/src/sys/Cross.cpp
+++ b/src/sys/Cross.cpp
@@ -115,7 +115,7 @@ void print_stack_trace(int s)
     "\n***********************************\n",reason);
 
         #ifndef NDEBUG
-  #ifdef _WIN32
+  #if !defined(_NDS) && !defined(__amigaos__)
 
  // fprintf(stderr,"%s\n",Abortable::stack_trace().c_str());
   #endif
@@ -134,8 +134,8 @@ void install_exception_handler()
     #else
     #ifndef __amigaos__
     // civilized
-    signal(SIGSEGV,print_stack_trace);
-  signal(SIGINT,print_stack_trace);
+    //signal(SIGSEGV,print_stack_trace);
+  //signal(SIGINT,print_stack_trace);
   #endif
     #endif
 }

--- a/src/sys/LargeFile.hpp
+++ b/src/sys/LargeFile.hpp
@@ -3,7 +3,7 @@
 
 #include "Long64.hpp"
 
-#if !defined __GLIBC_HAVE_LONG_LONG || defined _WIN32
+#if defined _WIN32
 // no 64-bit API available or directly supported
 #define open64 open
 #define fopen64 fopen

--- a/src/sys/MemoryEntryMap.cpp
+++ b/src/sys/MemoryEntryMap.cpp
@@ -95,6 +95,6 @@ void MemoryEntryMap::dump_allocated() const
 
 
     }
-  fprintf(stderr,"total allocated: %d blocks\n",m_items.size());
+  fprintf(stderr,"total allocated: %zu blocks\n",m_items.size());
 }
 #endif

--- a/src/sys/MyFile.cpp
+++ b/src/sys/MyFile.cpp
@@ -8,13 +8,12 @@
 #include "MemoryEntryMap.hpp"
 
 #include <cstdio>
-#ifdef _WIN32
-#include <dirent.h>
-#endif
 #ifdef __amigaos__
 #include <proto/dos.h>
 #include <proto/exec.h>
 #include <dos/dos.h>
+#else
+#include <dirent.h>
 #endif
 
 
@@ -156,12 +155,11 @@ StreamPosition MyFile::size() const
 
 }
 
-#endif
+#else
 
-#ifdef _WIN32
 bool MyFile::create_as_dir()
 {
-    #ifdef _NDS
+    #ifndef _WIN32
   return ::mkdir(m_name.c_str(),0666) == 0;
    #else
   return ::mkdir(m_name.c_str()) == 0;

--- a/src/sys/SoundPlay.cpp
+++ b/src/sys/SoundPlay.cpp
@@ -579,7 +579,7 @@ SoundPlay::SoundPlay(int master_sample_rate) : audio_open(false),m_master_sample
   sounds.resize(NUM_SOUNDS);
 
 }
-SoundPlay::SampleNode *SoundPlay::load(const MyString &filepath, int key, bool loop)
+SoundPlay::SampleNode *SoundPlay::load(const MyString &filepath, int key, bool loop, int)
 {
   SoundPlay::SampleNode *rc = 0;
 

--- a/src/sys/SoundPlay.hpp
+++ b/src/sys/SoundPlay.hpp
@@ -4,7 +4,7 @@
 #include "Abortable.hpp"
 #include "MyVector.hpp"
 
-#ifdef _WIN32
+#if !defined(_NDS) && !defined(__amigaos__)
 #define USE_SDL_MIXER 1
 #endif
 
@@ -59,7 +59,7 @@ public:
   };
 
   void close();
-  // priority (when needed from 1 to 64, 64 being the highest)
+  // priority only used on AmigaOS (when needed, from 1 to 64, 64 being the highest)
   SampleNode *load(const MyString &filename, int key, bool loop = false, int priority = 1);
   int play(int key);
   void stop(int i);
@@ -98,7 +98,7 @@ private:
     #ifdef _NDS
   MyString soundbank_file;
     #else
-  #ifdef _WIN32
+  #ifdef USE_SDL_MIXER
   Mix_Music *m_music;
   #else
   #endif

--- a/src/sys/SysCompat.hpp
+++ b/src/sys/SysCompat.hpp
@@ -11,7 +11,7 @@
 #define XOPEN_SOURCE_FORCED
 #endif
 
-#if defined Linux
+#if defined __linux__
 #include <features.h>
 #endif
 


### PR DESCRIPTION
Also fixes a bug; when the size of the file is -1, a segv occurs due to a null pointer dereference.

Because the stack trace function wasn't working for me I just disabled it.

I'm also wondering if exceptions should be enabled by default. I left a comment to that effect.