### PR TITLE
Use SDL threads instead of pthreads

### DIFF
--- a/src/sys/ThreadCondition.hpp
+++ b/src/sys/ThreadCondition.hpp
@@ -1,51 +1,49 @@
 #ifndef THREADCONDITION_H
 #define THREADCONDITION_H
 
-#include <pthread.h>
+#include "SDL/SDL.h"
 
 class ThreadCondition
 {
  public:
     ThreadCondition()
     {
-	pthread_cond_init(&m_cv,NULL);
-	pthread_mutex_init(&m_mutex,NULL);
+	m_cv = SDL_CreateCond();
+	m_mutex = SDL_CreateMutex();
     }
 
     ~ThreadCondition()
     {
-	pthread_cond_destroy(&m_cv);
-	pthread_mutex_destroy(&m_mutex);
-
+	SDL_DestroyCond(m_cv);
+	SDL_DestroyMutex(m_mutex);
     }
 
     void lock()
     {
-	pthread_mutex_lock(&m_mutex);
+	SDL_LockMutex(m_mutex);
     }
 
     void unlock()
     {
-	pthread_mutex_unlock(&m_mutex);
+	SDL_UnlockMutex(m_mutex);
     }
 
     void broadcast()
     {
-	pthread_cond_broadcast(&m_cv);
-
+	SDL_CondBroadcast(m_cv);
     }
 
     void wait()
     {
-	pthread_cond_wait(&m_cv,&m_mutex);
+	SDL_CondWait(m_cv, m_mutex);
     }
 
  private:
     ThreadCondition(const ThreadCondition &);
     ThreadCondition &operator=(const ThreadCondition &);
     
-    pthread_mutex_t m_mutex;
-    pthread_cond_t  m_cv;
+    SDL_mutex *m_mutex;
+    SDL_cond  *m_cv;
 
     
 };

--- a/src/sys/ThreadSafe.hpp
+++ b/src/sys/ThreadSafe.hpp
@@ -10,9 +10,9 @@
  * Used units *
  *------------*/
 
+#include "SDL/SDL.h"
 #include "MyAssert.hpp"
 
-#include <pthread.h>
 #include <strings.h>
 
 /*-----------------*
@@ -31,7 +31,7 @@
 class ThreadSafe
 {
  public:
-    typedef pthread_t ThreadId;
+    typedef Uint32 ThreadId;
 
     /**
      * critical section start
@@ -39,7 +39,7 @@ class ThreadSafe
 
     void cs_start() const
     {
-	pthread_mutex_lock(&m_creation_mutex);
+	SDL_LockMutex(m_creation_mutex);
     }
 
     /**
@@ -48,14 +48,14 @@ class ThreadSafe
 
     void cs_end() const
     {
-	pthread_mutex_unlock(&m_creation_mutex);
+	SDL_UnlockMutex(m_creation_mutex);
     }
 
     /**
      * me
      */
 
-    inline ThreadId me() const { return pthread_self(); }
+    inline ThreadId me() const { return SDL_ThreadID(); }
 
     /**
      * check if my id
@@ -74,13 +74,14 @@ class ThreadSafe
 
     ~ThreadSafe()
     {
-	pthread_mutex_destroy(&m_creation_mutex);
+	SDL_DestroyMutex(m_creation_mutex);
     }
 
  protected:
     ThreadSafe() : m_size(0)
     {
-	bool mutex_init_failure = pthread_mutex_init(&m_creation_mutex,NULL) != 0;
+        m_creation_mutex = SDL_CreateMutex();
+	bool mutex_init_failure = m_creation_mutex == 0;
 
 	if (mutex_init_failure)
 	{
@@ -99,7 +100,7 @@ class ThreadSafe
     int m_size;
 
  private:
-    mutable pthread_mutex_t m_creation_mutex;
+    mutable SDL_mutex *m_creation_mutex;
 };
 
 


### PR DESCRIPTION
SDL uses X on Linux, which requires for threads to be registered.

This uses SDL threads instead of pthreads, which may be more portable and fixes the issue with X on Linux.